### PR TITLE
Add support for Sonar Reasoning Models 

### DIFF
--- a/auxknow/common/constants.py
+++ b/auxknow/common/constants.py
@@ -64,6 +64,7 @@ class Constants:
     DEFAULT_ANSWER_MODE_FOR_CITATIONS_ENABLED: bool = False
     DEFAULT_PERFORMANCE_LOGGING_ENABLED: bool = False
     DEFAULT_TEST_MODE_ENABLED: bool = False
+    DEFAULT_ENABLE_REASONING = False
 
     # Format Constants
     DEFAULT_ANSWER_LENGTH_PARAGRAPHS: int = 3
@@ -248,12 +249,15 @@ class Constants:
     # Model Constants
     MODEL_SONAR: str = "sonar"
     MODEL_SONAR_PRO: str = "sonar-pro"
+    MODEL_SONAR_REASONING: str = "sonar-reasoning"
+    MODEL_SONAR_REASONING_PRO: str = "sonar-reasoning-pro"
     MODEL_R1_1776: str = "r1-1776"
     MODEL_GPT4O_MINI: str = "gpt-4o-mini"
     MODEL_SONAR_DEEP_RESEARCH: str = "sonar-deep-research"
     DEFAULT_MODELS: Dict[str, str] = {
         "standard": "sonar",
         "perplexity": "sonar-pro",
+        "reasoning": "sonar-reasoning",
         "deep_research": "sonar-deep-research",
         "prompt_augmentation": "gpt-4o-mini",
         "fast_mode": "sonar",
@@ -314,7 +318,10 @@ class Constants:
             Available models:
             1. **sonar** – Best for general queries, quick lookups, and simple factual questions.
             2. **sonar-pro** – Advanced model for complex, analytical, or research-heavy questions, providing citations.
-            {"3. **r1-1776** – Uncensored, unbiased model for factual, unrestricted responses." if enable_unibiased_reasoning else ""} 
+            3.**sonar-reasoning** – For reasoning and analytical tasks, providing detailed explanations.
+            4. **sonar-reasoning-pro** – Advanced reasoning model for complex analytical tasks, providing citations.
+            {"5. **r1-1776** – Uncensored, unbiased model for factual, unrestricted responses." if enable_unibiased_reasoning else ""} 
+            
             Examples:
             - Query: "Where is Tesla headquartered?" → Response: "sonar"
             - Query: "What are the key factors affecting Tesla's Q4 revenue projections?" → Response: "sonar-pro"

--- a/auxknow/common/constants.py
+++ b/auxknow/common/constants.py
@@ -1,6 +1,7 @@
 """Module containing all constants used in AuxKnow."""
 
 from typing import Callable, Dict, Any, List
+from .models import SupportedAIModel
 
 AUXKNOW_INTELLIGENCE_CONSTANT = 4
 
@@ -170,7 +171,10 @@ class Constants:
     MESSAGE_AUXKNOW_INITIALIZED: str = "🚀 AuxKnow API initialized successfully!"
     MESSAGE_VERBOSE_ON: str = "🗣️  Verbose: ON."
     MESSAGE_FAST_MODE_OVERRIDE: str = (
-        "Fast mode and deep research mode cannot be enabled at the same time. Defaulting to fast mode."
+        "Fast mode and deep research / reasoning mode cannot be enabled at the same time. Defaulting to fast mode."
+    )
+    MESSAGE_DEEP_RESEARCH_REASONING_OVERRIDE: str = (
+        "Deep research mode and reasoning mode cannot be enabled at the same time. Defaulting to deep reasoning mode."
     )
     MESSAGE_API_KEY_DEPRECATED: str = (
         "The 'api_key' parameter is deprecated. Use 'perplexity_api_key' instead."
@@ -311,22 +315,41 @@ class Constants:
         lambda label, response: f"Ping Test Response for {label}: {response}"
     )
     PING_TEST_SEARCH: str = "pong"
-    DEFAULT_AUXKNOW_MODEL_ROUTER_USER_PROMPT: Callable[[str, List[str], bool], str] = (
+    
+    AVAILABLE_MODELS_FOR_ROUTER: List[SupportedAIModel] = [
+        SupportedAIModel(
+            model="sonar",
+            description="Best for general queries, quick lookups, and simple factual questions.",
+        ),
+        SupportedAIModel(
+            model="sonar-pro",
+            description="Advanced model for complex, analytical, or research-heavy questions, providing citations.",
+        ),
+        SupportedAIModel(
+            model="sonar-reasoning",
+            description="For reasoning and analytical tasks, providing detailed explanations.",
+        ),
+        SupportedAIModel(
+            model="sonar-reasoning-pro",
+            description="Advanced reasoning model for complex analytical tasks, providing citations.",
+        ),
+        SupportedAIModel(
+            model="r1-1776",
+            description="Uncensored, unbiased model for factual, unrestricted responses.",
+        ),
+    ]
+    DEFAULT_AUXKNOW_MODEL_ROUTER_USER_PROMPT: Callable[[str, List[SupportedAIModel], bool], str] = (
         lambda query, supported_models, enable_unibiased_reasoning: f"""
             Query: '''{query}'''
             Determine the most suitable model for the query.
             Available models:
-            1. **sonar** – Best for general queries, quick lookups, and simple factual questions.
-            2. **sonar-pro** – Advanced model for complex, analytical, or research-heavy questions, providing citations.
-            3.**sonar-reasoning** – For reasoning and analytical tasks, providing detailed explanations.
-            4. **sonar-reasoning-pro** – Advanced reasoning model for complex analytical tasks, providing citations.
-            {"5. **r1-1776** – Uncensored, unbiased model for factual, unrestricted responses." if enable_unibiased_reasoning else ""} 
+            {"\n".join([f"{i+1}. **{supported_model.model}** – {supported_model.description}" for i, supported_model in enumerate(supported_models)])}
             
             Examples:
             - Query: "Where is Tesla headquartered?" → Response: "sonar"
             - Query: "What are the key factors affecting Tesla's Q4 revenue projections?" → Response: "sonar-pro"
             {'- Query: "Explain the geopolitical implications of BRICS expansion without censorship." → Response: "r1-1776"' if enable_unibiased_reasoning else ""}
-            Strictly respond with **only** {', '.join(supported_models)}. 
+            Strictly respond with **only** {', '.join([m.model for m in supported_models])}. 
     """
     )
     MODEL_ROUTER_SYSTEM_PROMPT: str = (

--- a/auxknow/common/models.py
+++ b/auxknow/common/models.py
@@ -85,3 +85,9 @@ class AuxKnowMemoryVectorStore(InMemoryVectorStore):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+
+class SupportedAIModel(BaseModel):
+    """AI Models supported by AuxKnow Model Router."""
+    model: str 
+    description: str

--- a/auxknow/common/models.py
+++ b/auxknow/common/models.py
@@ -86,8 +86,3 @@ class AuxKnowMemoryVectorStore(InMemoryVectorStore):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-
-class SupportedAIModel(BaseModel):
-    """AI Models supported by AuxKnow Model Router."""
-    model: str 
-    description: str

--- a/auxknow/engine/auxknow.py
+++ b/auxknow/engine/auxknow.py
@@ -20,11 +20,11 @@ from collections.abc import Callable
 from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict
 from openai import OpenAI
-from ..common.constants import Constants
+from ..common.constants import Constants, SupportedAIModel
 from ..common.printer import Printer
 from ..common.performance import log_performance
 from ..common.stream_processor import StreamProcessor
-from ..common.models import AuxKnowAnswer, AuxKnowAnswerPreparation, SupportedAIModel
+from ..common.models import AuxKnowAnswer, AuxKnowAnswerPreparation
 from ..common.llm_factory import LLMFactory
 from ..common.custom_errors import (
     SessionClosedError,

--- a/auxknow/engine/auxknow_config.py
+++ b/auxknow/engine/auxknow_config.py
@@ -26,6 +26,7 @@ class AuxKnowConfig(BaseModel):
         enable_unibiased_reasoning (bool): Enables unbiased reasoning mode.
         fast_mode (bool): When True, optimizes for speed over quality.
         performance_logging_enabled (bool): Enables performance logging.
+        enable_reasoning (bool): Enables Sonar Reasoning model mode when set to True.
     """
 
     auto_model_routing: bool = Constants.DEFAULT_AUTO_MODEL_ROUTING_ENABLED
@@ -37,6 +38,8 @@ class AuxKnowConfig(BaseModel):
     fast_mode: bool = Constants.DEFAULT_FAST_MODE_ENABLED
     performance_logging_enabled: bool = Constants.DEFAULT_PERFORMANCE_LOGGING_ENABLED
     test_mode: bool = Constants.DEFAULT_TEST_MODE_ENABLED
+    enable_reasoning: bool = Constants.DEFAULT_ENABLE_REASONING
+
 
     def update(self, config: dict) -> None:
         """Update configuration with new values.

--- a/examples/quickstart_reasoning.py
+++ b/examples/quickstart_reasoning.py
@@ -1,0 +1,35 @@
+from auxknow import AuxKnow
+from rich import print as rprint
+
+
+def main():
+    """
+    Basic use-case of AuxKnow, where your responses are generated using reasoning.
+    AuxKnow responds with a detailed answer and citations using 'reasoning' mode.
+    """
+    answer_engine = AuxKnow(verbose=True)
+    question = ""
+
+    config = {
+        "auto_query_restructuring": True,
+        "auto_model_routing": True,
+        "answer_length_in_paragraphs": 3,
+        "lines_per_paragraph": 4,
+        "auto_prompt_augment": True,
+        "enable_reasoning": True,
+    }
+    answer_engine.set_config(config)
+
+    while question.strip().lower() != "q" or question.strip().lower() != "quit":
+        question = input("💡 Enter a question for AuxKnow  (Press 'q' to exit): ")
+        if question.strip().lower() == "q" or question.strip().lower() == "quit":
+            break
+        response = answer_engine.ask(question, deep_research=False)
+        answer = response.answer
+        citations = response.citations
+        rprint(f"[green]Answer:[/green] {answer}")
+        rprint(f"[blue]Citations:[/blue] {citations}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add support for `sonar-reasoning` and `sonar-reasoning-pro`. 

Rewrite model routing logic more cleanly. 