### PR TITLE
Add enable_reasoning examples, update API usage, and pass the parameter where needed.

### DIFF
--- a/auxknow/engine/auxknow.py
+++ b/auxknow/engine/auxknow.py
@@ -174,6 +174,7 @@ class AuxKnowSession(BaseModel):
         question: str,
         deep_research=Constants.DEFAULT_DEEP_RESEARCH_ENABLED,
         fast_mode=Constants.DEFAULT_FAST_MODE_ENABLED,
+        enable_reasoning=Constants.DEFAULT_ENABLE_REASONING,
         for_citations=Constants.DEFAULT_ANSWER_MODE_FOR_CITATIONS_ENABLED,
         get_context_callback: Callable[[str], str] = None,
         update_context_callback: Callable[[str, AuxKnowAnswer], None] = None,
@@ -184,6 +185,7 @@ class AuxKnowSession(BaseModel):
             question (str): The question to ask.
             deep_research (bool): Whether to enable deep research mode. (Default: False)
             fast_mode (bool): When True, overrides other settings for fastest response.
+            enable_reasoning (bool): Whether to enable reasoning mode. (Default: False)
             for_citations (bool): Whether to enable citation mode. (Defaults to DEFAULT_ANSWER_MODE_FOR_CITATIONS_ENABLED).
             get_context_callback (Callable[[str], str]): Callback to load context for the question.
             update_context_callback (Callable[[str, AuxKnowAnswer], None]): Callback to update context with the answer.
@@ -202,6 +204,7 @@ class AuxKnowSession(BaseModel):
             question=question,
             deep_research=deep_research,
             fast_mode=fast_mode,
+            enable_reasoning=enable_reasoning,
             get_context_callback=get_context_callback,
             update_context_callback=update_context_callback,
             for_citations=for_citations,
@@ -212,6 +215,7 @@ class AuxKnowSession(BaseModel):
         question: str,
         deep_research=Constants.DEFAULT_DEEP_RESEARCH_ENABLED,
         fast_mode=Constants.DEFAULT_FAST_MODE_ENABLED,
+        enable_reasoning=Constants.DEFAULT_ENABLE_REASONING,
         for_citations=Constants.DEFAULT_ANSWER_MODE_FOR_CITATIONS_ENABLED,
         get_context_callback: Callable[[str], str] = None,
         update_context_callback: Callable[[str, AuxKnowAnswer], None] = None,
@@ -222,6 +226,7 @@ class AuxKnowSession(BaseModel):
             question (str): The question to ask.
             deep_research (bool): Whether to enable deep research mode. (Default: False)
             fast_mode (bool): When True, overrides other settings for fastest response.
+            enable_reasoning (bool): Whether to enable reasoning mode. (Default: False)
             get_context_callback (Callable[[str], str]): Callback to load context for the question.
             update_context_callback (Callable[[str, AuxKnowAnswer], None]): Callback to update context with the answer.
             for_citations (bool): Whether to enable citation mode. (Defaults to DEFAULT_ANSWER_MODE_FOR_CITATIONS_ENABLED).
@@ -240,6 +245,7 @@ class AuxKnowSession(BaseModel):
             question=question,
             deep_research=deep_research,
             fast_mode=fast_mode,
+            enable_reasoning=enable_reasoning,
             for_citations=for_citations,
             get_context_callback=get_context_callback,
             update_context_callback=update_context_callback,
@@ -280,6 +286,7 @@ class AuxKnow:
         enable_unibiased_reasoning: bool = Constants.DEFAULT_ENABLE_UNBIASED_REASONING,
         fast_mode: bool = Constants.DEFAULT_FAST_MODE_ENABLED,
         test_mode: bool = Constants.DEFAULT_TEST_MODE_ENABLED,
+        enable_reasoning: bool = Constants.DEFAULT_ENABLE_REASONING,
     ):
         """Initialize the AuxKnow instance.
 
@@ -295,6 +302,7 @@ class AuxKnow:
             auto_query_restructuring (bool): Whether to enable automatic query restructuring. Default is False.
             enable_unibiased_reasoning (bool): Whether to enable unbiased reasoning mode. Default is True.
             fast_mode (bool): Whether to enable fast mode. Default is False.
+            enable_reasoning (bool): Whether to enable reasoning mode. Default is False.
         """
         Printer.verbose_logger(
             verbose,
@@ -312,6 +320,8 @@ class AuxKnow:
             auto_query_restructuring=auto_query_restructuring,
             enable_unibiased_reasoning=enable_unibiased_reasoning,
             fast_mode=fast_mode,
+            enable_reasoning=enable_reasoning,
+
             test_mode=test_mode,
         )
         self.sessions: dict[str, AuxKnowSession] = {}
@@ -836,6 +846,7 @@ class AuxKnow:
             - enable_unbiased_reasoning (int): Enable or disable unbiased reasoning mode (default: `True`).
             - fast_mode (bool): When enabled, overrides other settings for fastest response (default: `False`).
             - performance_logging_enabled (bool): Enable or disable performance logging (default: `False`).
+            - enable_reasoning (bool): Enable or disable reasoning mode (default: `False`).
         """
         return self.config.update(config=config)
 

--- a/auxknow/engine/auxknow.py
+++ b/auxknow/engine/auxknow.py
@@ -677,6 +677,9 @@ class AuxKnow:
     def _load_supported_model_names(self, enable_reasoning: bool) -> list[str]:
         """Load the supported model names.
 
+        Args:
+            enable_reasoning (bool): Whether to enable reasoning mode.
+
         Returns:
             list[str]: The list of supported model names.
         """
@@ -924,11 +927,7 @@ class AuxKnow:
             question (str): The question being asked
             deep_research (bool): Whether deep research mode is enabled
             fast_mode (bool): Whether fast mode is enabled (overrides other settings)
-            reasoning (bool): Whether reasoning mode is enabled
-            reasoning_pro (bool): Whether reasoning pro mode is enabled
-
-        Returns:
-            str: The model name to use
+            enable_reasoning (bool): Whether reasoning mode is enabled
         """
 
         fast_mode = self.config.fast_mode or fast_mode
@@ -1023,6 +1022,7 @@ class AuxKnow:
         for_citations=Constants.DEFAULT_ANSWER_MODE_FOR_CITATIONS_ENABLED,
         deep_research: bool = Constants.DEFAULT_DEEP_RESEARCH_ENABLED,
         fast_mode: bool = Constants.DEFAULT_FAST_MODE_ENABLED,
+        enable_reasoning: bool = Constants.DEFAULT_ENABLE_REASONING,
         get_context_callback: Callable[[str], str] = None,
         answer_id=str(uuid4()),
     ) -> AuxKnowAnswerPreparation:
@@ -1031,8 +1031,10 @@ class AuxKnow:
         Args:
             question (str): The question to ask
             context (str): Initial context
+            for_citations (bool): Whether to enable citation mode
             deep_research (bool): Deep research mode flag
             fast_mode (bool): Fast mode flag
+            enable_reasoning (bool): Reasoning mode flag
             get_context_callback (Callable): Context callback
 
         Returns:
@@ -1061,7 +1063,7 @@ class AuxKnow:
             )
 
         question, model = self._get_ask_question_and_model(
-            question, deep_research, fast_mode
+            question, deep_research, fast_mode, enable_reasoning
         )
 
         Printer.verbose_logger(
@@ -1103,16 +1105,33 @@ class AuxKnow:
         for_citations=Constants.DEFAULT_ANSWER_MODE_FOR_CITATIONS_ENABLED,
         deep_research=Constants.DEFAULT_DEEP_RESEARCH_ENABLED,
         fast_mode=Constants.DEFAULT_FAST_MODE_ENABLED,
+        enable_reasoning: bool = Constants.DEFAULT_ENABLE_REASONING,
         get_context_callback: Callable[[str], str] = None,
         update_context_callback: Callable[[str, AuxKnowAnswer], None] = None,
     ) -> AuxKnowAnswer:
         answer_id = str(uuid4())
+        """Ask a question and get an answer.
+
+        Args:
+            question (str): The question to ask
+            context (str): Initial context
+            for_citations (bool): Whether to enable citation mode
+            deep_research (bool): Deep research mode flag
+            fast_mode (bool): Fast mode flag
+            enable_reasoning (bool): Reasoning mode flag
+            get_context_callback (Callable): Context callback
+            update_context_callback (Callable): Context update callback
+
+        Returns:
+            AuxKnowAnswer: The answer to the question
+        """
         try:
             preparation_response = self._prepare_ask_request(
                 question=question,
                 context=context,
                 deep_research=deep_research,
                 fast_mode=fast_mode,
+                enable_reasoning=enable_reasoning,
                 get_context_callback=get_context_callback,
                 for_citations=for_citations,
                 answer_id=answer_id,
@@ -1199,16 +1218,33 @@ class AuxKnow:
         for_citations=Constants.DEFAULT_ANSWER_MODE_FOR_CITATIONS_ENABLED,
         deep_research=Constants.DEFAULT_DEEP_RESEARCH_ENABLED,
         fast_mode=Constants.DEFAULT_FAST_MODE_ENABLED,
+        enable_reasoning: bool = Constants.DEFAULT_ENABLE_REASONING,
         get_context_callback: Callable[[str], str] = None,
         update_context_callback: Callable[[str, AuxKnowAnswer], None] = None,
     ) -> Generator[AuxKnowAnswer, None, None]:
         answer_id = str(uuid4())
+        """Ask a question and get a streaming answer.
+
+        Args:
+            question (str): The question to ask
+            context (str): Initial context
+            for_citations (bool): Whether to enable citation mode
+            deep_research (bool): Deep research mode flag
+            fast_mode (bool): Fast mode flag
+            enable_reasoning (bool): Reasoning mode flag
+            get_context_callback (Callable): Context callback
+            update_context_callback (Callable): Context update callback
+
+        Returns:
+            Generator[AuxKnowAnswer]: A generator that yields AuxKnowAnswer objects
+        """
         try:
             preparation_response = self._prepare_ask_request(
                 question=question,
                 context=context,
                 deep_research=deep_research,
                 fast_mode=fast_mode,
+                enable_reasoning=enable_reasoning,
                 get_context_callback=get_context_callback,
                 for_citations=for_citations,
                 answer_id=answer_id,
@@ -1321,7 +1357,7 @@ class AuxKnow:
         return context
 
     def _get_ask_question_and_model(
-        self, question: str, deep_research: bool, fast_mode: bool
+        self, question: str, deep_research: bool, fast_mode: bool, enable_reasoning: bool
     ) -> tuple[str, str]:
         """
         Get the question and model for asking a question.
@@ -1330,6 +1366,7 @@ class AuxKnow:
             question (str): The question to ask.
             deep_research (bool): Whether to enable deep research mode.
             fast_mode (bool): Whether to enable fast mode.
+            enable_reasoning (bool): Whether to enable reasoning mode.
 
         Returns:
             str: The question.
@@ -1341,7 +1378,7 @@ class AuxKnow:
             question = self.__restructure_query(question)
 
         model = self._get_model(
-            question=question, deep_research=deep_research, fast_mode=fast_mode
+            question=question, deep_research=deep_research, fast_mode=fast_mode, enable_reasoning=enable_reasoning
         )
 
         return question, model

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -20,6 +20,7 @@ Key features include:
 - Unbiased reasoning mode (enabled by default).
 - **Deep Research Mode** for in-depth responses (configurable per query).
 - **Fast Mode** for quickest possible responses (configurable globally or per query).
+- **Reasoning Mode** for logical and structured responses (configurable per query).
 
 Both **Auto Prompt Augmentation** and **Unbiased Reasoning Mode** are enabled by default but can be configured using `set_config`.
 
@@ -47,10 +48,11 @@ When initializing AuxKnow, you can provide the following parameters:
 - `auto_query_restructuring` (bool): Enable automatic query restructuring. Default: False
 - `enable_unibiased_reasoning` (bool): Enable unbiased reasoning mode. Default: True
 - `fast_mode` (bool): Enable fast mode for quicker responses. Default: False
+- `enable_reasoning` (bool): Enable reasoning mode for logical and structured responses. Default: False
 
-#### Key Functionalities
+### Key Functionalities
 
-##### Querying (`ask`)
+#### Querying (`ask`)
 
 Sends a query to AuxKnow for an answer. Queries can optionally include additional context.
 
@@ -61,6 +63,7 @@ Sends a query to AuxKnow for an answer. Queries can optionally include additiona
 - `for_citations` (bool, optional): Whether to optimize response for citation generation. Default: False
 - `deep_research` (bool, optional): Whether to enable deep research mode. Default: False
 - `fast_mode` (bool, optional): When enabled, overrides other settings for fastest response. Default: False
+- `enable_reasoning` (bool, optional): Whether to enable reasoning mode for logical and structured responses. Default: False
 - `get_context_callback` (Callable[[str], str], optional): Function to load context for the question.
 - `update_context_callback` (Callable[[str, AuxKnowAnswer], None], optional): Function to update context with the answer.
 
@@ -75,7 +78,7 @@ Sends a query to AuxKnow for an answer. Queries can optionally include additiona
 
 ```python
 auxknow = AuxKnow(api_key="your_api_key", openai_api_key="your_openai_api_key")
-response = auxknow.ask("What is quantum computing?")
+response = auxknow.ask("What is quantum computing?", enable_reasoning=True)
 print(response.answer)
 ```
 
@@ -89,7 +92,7 @@ response = auxknow.ask("What is quantum computing?")
 print(response.answer)
 ```
 
-##### Querying with Streaming (`ask_stream`)
+### Querying with Streaming (`ask_stream`)
 
 Sends a query to AuxKnow for an answer with streaming responses.
 
@@ -99,6 +102,7 @@ Sends a query to AuxKnow for an answer with streaming responses.
 - `context` (optional): Additional information to provide context.
 - `deep_research` (optional): Enable deep research mode for in-depth responses.
 - `fast_mode` (optional): When enabled, overrides other settings to provide fastest possible response.
+- `enable_reasoning` (optional): Whether to enable reasoning mode for logical and structured responses. Default: False
 
 **Outputs:**
 
@@ -108,11 +112,28 @@ Sends a query to AuxKnow for an answer with streaming responses.
 
 ```python
 auxknow = AuxKnow(api_key="your_api_key", openai_api_key="your_openai_api_key")
-for response in auxknow.ask_stream("What is quantum computing?"):
+for response in auxknow.ask_stream("What is quantum computing?", enable_reasoning=True):
     print(response.answer)
 ```
 
-##### Deep Research Mode (`deep_research=True`)
+### Reasoning Mode (`enable_reasoning=True`)
+
+**Reasoning Mode** enables AuxKnow to provide logical, structured, and analytical responses. This mode is best suited for queries requiring logical explanations, decision-making support, or analytical problem-solving.
+
+**When to use:**
+
+- When logical and structured responses are required.
+- For analytical problem-solving or decision-making support.
+- For queries requiring reasoning-based explanations.
+
+**Example Usage:**
+
+```python
+response = auxknow.ask("Explain the ethical implications of AI in healthcare.", enable_reasoning=True)
+print(response.answer)
+```
+
+### Deep Research Mode (`deep_research=True`)
 
 **Deep Research Mode** enables AuxKnow to conduct thorough research and provide well-structured, highly detailed responses. This mode is best suited for complex, analytical, or research-heavy queries where in-depth responses are necessary.
 
@@ -129,7 +150,7 @@ response = auxknow.ask("Explain the fundamentals of quantum mechanics", deep_res
 print(response.answer)
 ```
 
-##### Session Management (`create_session`)
+### Session Management (`create_session`)
 
 Initiates a new session to group related queries and maintain context across multiple interactions.
 
@@ -141,12 +162,12 @@ Initiates a new session to group related queries and maintain context across mul
 
 ```python
 session = auxknow.create_session()
-response = session.ask("What is the speed of light?", deep_research=False)
+response = session.ask("What is the speed of light?", enable_reasoning=True)
 print(response.answer)
 session.close()
 ```
 
-##### Configuration (`set_config` and `get_config`)
+### Configuration (`set_config` and `get_config`)
 
 Modify or retrieve the current settings for AuxKnow.
 
@@ -156,17 +177,12 @@ Modify or retrieve the current settings for AuxKnow.
   - `auto_query_restructuring`: Enable automatic query improvement.
   - `auto_model_routing`: Enable automatic selection of the best model.
   - `answer_length_in_paragraphs`: Set the desired response length in paragraphs.
-  - `lines_per_paragraph`: Define the number of lines per paragraph.
+  - `lines_per_paragraph`: Define the number of lines per paragraph in responses.
   - `auto_prompt_augment`: Enable or disable automatic prompt augmentation (default: `True`).
   - `enable_unbiased_reasoning`: Enable or disable unbiased reasoning mode (default: `True`).
+  - `enable_reasoning`: Enable or disable reasoning mode (default: `False`).
   - `fast_mode`: When enabled, overrides other settings for fastest response (default: `False`).
   - `performance_logging_enabled`: Enable or disable performance logging (default: `False`).
-
-**Note:** When setting `answer_length_in_paragraphs` and `lines_per_paragraph`, the values are automatically capped at their maximum limits. If exceeded, they default to their standard values with a warning message.
-
-**Outputs for `get_config`:**
-
-- The current configuration object.
 
 **Example Usage:**
 
@@ -178,36 +194,13 @@ config = {
     "lines_per_paragraph": 5,
     "auto_prompt_augment": False,  # Disable prompt augmentation
     "enable_unbiased_reasoning": False,  # Disable unbiased reasoning
+    "enable_reasoning": True,  # Enable reasoning mode
     "fast_mode": True,  # Enable fast mode
     "performance_logging_enabled": True  # Enable performance logging
 }
 auxknow.set_config(config)
 current_config = auxknow.get_config()
-print(current_config.auto_query_restructuring)
-```
-
-##### Fast Mode
-
-**Fast Mode** configures AuxKnow to provide the quickest possible responses.
-
-**When to use:**
-
-- When response speed is critical.
-- For simple, straightforward queries.
-- In high-throughput scenarios.
-
-**Example Usage:**
-
-```python
-# Global configuration
-config = {
-    "fast_mode": True
-}
-auxknow.set_config(config)
-
-# Per-query configuration
-response = auxknow.ask("What is quantum computing?", fast_mode=True)
-print(response.answer)
+print(current_config.enable_reasoning)
 ```
 
 ---
@@ -234,6 +227,7 @@ Send a query while maintaining the session’s context.
 - `question` (str): The query string.
 - `deep_research` (bool, optional): Enable deep research mode. Default: False.
 - `fast_mode` (bool, optional): When enabled, overrides other settings for fastest response. Default: False.
+- `enable_reasoning` (bool, optional): Whether to enable reasoning mode for logical and structured responses. Default: False.
 - `get_context_callback` (Callable[[str], str], optional): Function to load context for the question.
 - `update_context_callback` (Callable[[str, AuxKnowAnswer], None], optional): Function to update context with the answer.
 
@@ -247,12 +241,12 @@ Send a query while maintaining the session’s context.
 
 ```python
 session = auxknow.create_session()
-response = session.ask("Explain the theory of relativity.", deep_research=False)
+response = session.ask("Explain the theory of relativity.", enable_reasoning=True)
 print(response.answer)
 session.close()
 ```
 
-##### Querying with Streaming within a Session (`session.ask_stream`)
+### Querying with Streaming within a Session (`session.ask_stream`)
 
 Send a query while maintaining the session’s context with streaming responses.
 
@@ -260,6 +254,7 @@ Send a query while maintaining the session’s context with streaming responses.
 
 - `question`: The query string.
 - `deep_research` (optional): Enable deep research mode.
+- `enable_reasoning` (optional): Whether to enable reasoning mode for logical and structured responses. Default: False
 
 **Outputs:**
 
@@ -269,12 +264,12 @@ Send a query while maintaining the session’s context with streaming responses.
 
 ```python
 session = auxknow.create_session()
-for response in session.ask_stream("Explain the theory of relativity.", deep_research=False):
+for response in session.ask_stream("Explain the theory of relativity.", enable_reasoning=True):
     print(response.answer)
 session.close()
 ```
 
-##### Closing a Session (`close`)
+### Closing a Session (`close`)
 
 Terminates the session, disallowing further queries.
 
@@ -301,7 +296,7 @@ Retrieves an existing session by its ID.
 ```python
 session = auxknow.get_session("session_id_here")
 if session:
-    response = session.ask("What is quantum computing?")
+    response = session.ask("What is quantum computing?", enable_reasoning=True)
 ```
 
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,6 +30,7 @@ response = auxknow.ask(
     context="",  # Optional context
     deep_research=False,  # Optional, enables in-depth research mode
     fast_mode=False,  # Optional, prioritizes speed over quality
+    enable_reasoning=False,  # Optional, enables reasoning mode
     for_citations=True  # Optional, enables citation extraction
 )
 
@@ -52,6 +53,7 @@ for partial_response in auxknow.ask_stream(
     "Explain quantum mechanics.",
     deep_research=False,  # Optional
     fast_mode=False,  # Optional
+    enable_reasoning=False,  # Optional
     for_citations=True  # Optional
 ):
     print(partial_response.answer, end="")
@@ -77,13 +79,14 @@ response = session.ask(
     "What are the main principles of relativity?",
     deep_research=True,  # Optional
     fast_mode=False,  # Optional
+    enable_reasoning=False,  # Optional
     for_citations=True  # Optional
 )
 print("Answer:", response.answer)
 print("Citations:", response.citations)
 
 # Continue with contextual queries
-response = session.ask("How does it relate to quantum mechanics?")
+response = session.ask("How does it relate to quantum mechanics?", enable_reasoning=True)
 print("Answer:", response.answer)
 print("Citations:", response.citations)
 
@@ -109,6 +112,7 @@ task_config = {
     "lines_per_paragraph": 5,  # Sets lines per paragraph
     "auto_prompt_augment": True,  # Enables prompt enhancement
     "enable_unbiased_reasoning": True,  # Enables unbiased mode
+    "enable_reasoning": False,  # Enables reasoning mode
     "fast_mode": False,  # Fast response mode
     "performance_logging_enabled": False  # Performance tracking
 }
@@ -181,6 +185,38 @@ for partial_response in auxknow.ask_stream(
     print(partial_response.answer, end="")
 ```
 
+### Reasoning Mode
+
+Reasoning mode provides logical and structured responses suitable for:
+
+- Analytical Problem Solving
+- Logical Explanations
+- Decision-Making Support
+
+```python
+from auxknow import AuxKnow
+
+auxknow = AuxKnow(perplexity_api_key="your_api_key", openai_api_key="your_openai_api_key")
+
+# Reasoning mode with standard ask
+response = auxknow.ask(
+    "Explain the ethical implications of AI in healthcare.",
+    enable_reasoning=True,
+    for_citations=True
+)
+
+print("Answer:", response.answer)
+print("Citations:", response.citations)
+
+# Reasoning mode with streaming
+for partial_response in auxknow.ask_stream(
+    "Analyze the impact of blockchain on supply chain management.",
+    enable_reasoning=True,
+    for_citations=True
+):
+    print(partial_response.answer, end="")
+```
+
 ### Citation Extraction
 
 AuxKnow automatically extracts citations for responses:
@@ -220,5 +256,6 @@ print("AuxKnow Version:", version)
 - Frame your queries as questions for better results
 - Deep Research mode is recommended for complex queries requiring detailed analysis
 - Fast mode overrides other settings for maximum speed
+- Reasoning mode provides logical and structured responses
 - Citations are automatically extracted when `for_citations=True`
 - Use sessions for maintaining context in conversational interactions

--- a/examples copy/contextual_search.py
+++ b/examples copy/contextual_search.py
@@ -1,0 +1,48 @@
+from auxknow import AuxKnow
+from rich import print as rprint
+
+fields = {
+    "name": "Neo Wang",
+    "email": "neo.wang@skynet.ai",
+    "organization": "Skynet",
+    "position": "AI Research Engineer",
+    "location": "San Francisco, California",
+    "education": "Ph.D. in Computer Science",
+    "experience": "5 years",
+    "skills": "Python, Machine Learning, NLP",
+}
+
+GLOBAL_CONTEXT = f""""
+- My name is {fields['name']}
+- My email is {fields['email']}
+- I work at {fields['organization']} as an {fields['position']}
+- I am located in {fields['location']}
+- I have a {fields['education']}
+- I have {fields['experience']} of experience
+- My skills include {fields['skills']}
+"""
+
+
+def main():
+    """
+    Basic use-case of AuxKnow, where you can load custom context and ask a question.
+    AuxKnow responds with contextual awareness, including the context in the response.
+    """
+    answer_engine = AuxKnow(verbose=True)
+    question = ""
+
+    while question.strip().lower() != "q" or question.strip().lower() != "quit":
+        question = input(
+            "💡 Enter a question for Contextual AuxKnow (Press 'q' to exit): "
+        )
+        if question.strip().lower() == "q" or question.strip().lower() == "quit":
+            break
+        response = answer_engine.ask(question, context=GLOBAL_CONTEXT)
+        answer = response.answer
+        citations = response.citations
+        rprint(f"[green]Answer:[/green] {answer}")
+        rprint(f"[blue]Citations:[/blue] {citations}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples copy/prompt_augmentation.py
+++ b/examples copy/prompt_augmentation.py
@@ -1,0 +1,31 @@
+from auxknow import AuxKnow
+from rich import print as rprint
+
+
+def run_auxknow(auxknow: AuxKnow, question, label: str):
+    response = auxknow.ask(question)
+    answer = response.answer
+    citations = response.citations
+    rprint(f"[green]Answer ({label}):[/green] {answer}")
+    rprint(f"[blue]Citations ({label}):[/blue] {citations}")
+
+
+def main():
+    """
+    Basic use-case of AuxKnow, where you can enable prompt augmentation.
+    Prompt augmentation is a technique to enhance the quality of the answer.
+    """
+    auxknow_naive = AuxKnow(verbose=True)
+    auxknow_prompt_augment = AuxKnow(verbose=True, auto_prompt_augment=True)
+    question = ""
+
+    while question.strip().lower() != "q" or question.strip().lower() != "quit":
+        question = input("💡 Enter a question for AuxKnow  (Press 'q' to exit): ")
+        if question.strip().lower() == "q" or question.strip().lower() == "quit":
+            break
+        run_auxknow(auxknow_naive, question, "Naive")
+        run_auxknow(auxknow_prompt_augment, question, "Prompt Augment")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples copy/quickstart.py
+++ b/examples copy/quickstart.py
@@ -1,0 +1,25 @@
+from auxknow import AuxKnow
+from rich import print as rprint
+
+
+def main():
+    """
+    Basic use-case of AuxKnow, ask a question and get an answer.
+    In this instance, the user has to wait for the complete answer to be generated before seeing the response.
+    """
+    answer_engine = AuxKnow(verbose=True)
+    question = ""
+
+    while question.strip().lower() != "q" or question.strip().lower() != "quit":
+        question = input("💡 Enter a question for AuxKnow  (Press 'q' to exit): ")
+        if question.strip().lower() == "q" or question.strip().lower() == "quit":
+            break
+        response = answer_engine.ask(question)
+        answer = response.answer
+        citations = response.citations
+        rprint(f"[green]Answer:[/green] {answer}")
+        rprint(f"[blue]Citations:[/blue] {citations}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples copy/quickstart_deep_research.py
+++ b/examples copy/quickstart_deep_research.py
@@ -1,0 +1,34 @@
+from auxknow import AuxKnow
+from rich import print as rprint
+
+
+def main():
+    """
+    Basic use-case of AuxKnow, where you perform deep research.
+    AuxKnow responds with a detailed answer and citations using 'deep research' mode.
+    """
+    answer_engine = AuxKnow(verbose=True)
+    question = ""
+
+    config = {
+        "auto_query_restructuring": True,
+        "auto_model_routing": False,
+        "answer_length_in_paragraphs": 10,
+        "lines_per_paragraph": 10,
+        "auto_prompt_augment": True,
+    }
+    answer_engine.set_config(config)
+
+    while question.strip().lower() != "q" or question.strip().lower() != "quit":
+        question = input("💡 Enter a question for AuxKnow  (Press 'q' to exit): ")
+        if question.strip().lower() == "q" or question.strip().lower() == "quit":
+            break
+        response = answer_engine.ask(question, deep_research=True)
+        answer = response.answer
+        citations = response.citations
+        rprint(f"[green]Answer:[/green] {answer}")
+        rprint(f"[blue]Citations:[/blue] {citations}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples copy/quickstart_reasoning.py
+++ b/examples copy/quickstart_reasoning.py
@@ -1,0 +1,35 @@
+from auxknow import AuxKnow
+from rich import print as rprint
+
+
+def main():
+    """
+    Basic use-case of AuxKnow, where your responses are generated using reasoning.
+    AuxKnow responds with a detailed answer and citations using 'reasoning' mode.
+    """
+    answer_engine = AuxKnow(verbose=True)
+    question = ""
+
+    config = {
+        "auto_query_restructuring": True,
+        "auto_model_routing": True,
+        "answer_length_in_paragraphs": 3,
+        "lines_per_paragraph": 4,
+        "auto_prompt_augment": True,
+        "enable_reasoning": True,
+    }
+    answer_engine.set_config(config)
+
+    while question.strip().lower() != "q" or question.strip().lower() != "quit":
+        question = input("💡 Enter a question for AuxKnow  (Press 'q' to exit): ")
+        if question.strip().lower() == "q" or question.strip().lower() == "quit":
+            break
+        response = answer_engine.ask(question, deep_research=False)
+        answer = response.answer
+        citations = response.citations
+        rprint(f"[green]Answer:[/green] {answer}")
+        rprint(f"[blue]Citations:[/blue] {citations}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples copy/quickstart_sonar_reasoning.py
+++ b/examples copy/quickstart_sonar_reasoning.py
@@ -1,0 +1,35 @@
+from auxknow import AuxKnow
+from rich import print as rprint
+import os
+from dotenv import load_dotenv
+load_dotenv(dotenv_path=".env.test", override=True,verbose=True)
+
+def main():
+    """
+    This is a basic use-case of AuxKnow, where your responses are generated using sonar reasoning mode.
+    AuxKnow responds with a detailed answer and citations using 'sonar-reasoning' mode.
+    """
+    answer_engine = AuxKnow(verbose=True, api_key=os.getenv("PERPLEXITY_API_KEY"),openai_api_key=os.getenv("OPENAI_API_KEY"))
+    question = ""
+
+    config={
+        "auto_query_restructuring": True,
+        "auto_model_routing": True,
+        "answer_length_in_paragraphs": 3,
+        "lines_per_paragraph": 4,
+        "auto_prompt_augment": True,
+        "enable_reasoning": True,
+    }
+
+    answer_engine.set_config(config)
+
+    response = answer_engine.ask(question, enable_reasoning=True)
+    answer = response.answer
+    citations = response.citations
+    rprint(f"[green]Answer:[/green] {answer}")
+    rprint(f"[blue]Citations:[/blue] {citations}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/examples copy/session_chat.py
+++ b/examples copy/session_chat.py
@@ -1,0 +1,41 @@
+from auxknow import AuxKnow
+import os
+from rich import print as rprint
+from dotenv import load_dotenv
+
+load_dotenv(override=True, dotenv_path=".env")
+
+perplexity_api_key = os.getenv("PERPLEXITY_API_KEY")
+openai_api_key = os.getenv("OPENAI_API_KEY")
+
+
+def main():
+    """
+    Basic use-case of AuxKnow, where you can create chat sessions.
+    Each session is an independent conversation with AuxKnow and can be used to maintain context.
+    The session needs to be closed at the end of the conversation to release the context.
+    """
+    answer_engine = AuxKnow(
+        api_key=perplexity_api_key,
+        openai_api_key=openai_api_key,
+        verbose=True,
+    )
+    session = answer_engine.create_session()
+
+    question = ""
+
+    while question.strip().lower() != "q" or question.strip().lower() != "quit":
+        question = input("💡 Enter a question for AuxKnow  (Press 'q' to exit): ")
+        if question.strip().lower() == "q" or question.strip().lower() == "quit":
+            break
+        response = session.ask(question, fast_mode=True)
+        answer = response.answer
+        citations = response.citations
+        rprint(f"[green]Answer:[/green] {answer}")
+        rprint(f"[blue]Citations:[/blue] {citations}")
+
+    session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples copy/session_chat_streaming.py
+++ b/examples copy/session_chat_streaming.py
@@ -1,0 +1,40 @@
+import sys
+from auxknow import AuxKnow
+from rich import print as rprint
+
+
+def main():
+    """
+    Basic use-case of AuxKnow, where AuxKnow learns the context of the conversation and improves it's responses.
+    AuxKnow responds with contextual awareness, including the context in the response.
+    """
+    answer_engine = AuxKnow(verbose=True)
+    session = answer_engine.create_session()
+    question = ""
+
+    while question.strip().lower() != "q" or question.strip().lower() != "quit":
+        question = input("💡 Enter a question for AuxKnow  (Press 'q' to exit): ")
+        if question.strip().lower() == "q" or question.strip().lower() == "quit":
+            break
+        response = session.ask_stream(question, fast_mode=True)
+
+        answer = "Answer: "
+        citations = ""
+        for partial_response in response:
+            if partial_response.answer and not partial_response.is_final:
+                answer += partial_response.answer
+                sys.stdout.write(partial_response.answer)
+                sys.stdout.flush()
+            if partial_response.citations:
+                citations = partial_response.citations
+            if partial_response.is_final:
+                print()
+                break
+
+        rprint(f"[blue]Citations:[/blue] {citations}")
+
+    session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples copy/streaming.py
+++ b/examples copy/streaming.py
@@ -1,0 +1,37 @@
+import sys
+from auxknow import AuxKnow
+from rich import print as rprint
+
+
+def main():
+    """ "
+    Basic use-case of AuxKnow, where the user sees the response as it is being generated with streaming.
+    This instance uses the default configuration along with streaming.
+    """
+    answer_engine = AuxKnow(verbose=True)
+    question = ""
+
+    while question.strip().lower() != "q" or question.strip().lower() != "quit":
+        question = input("💡 Enter a question for AuxKnow  (Press 'q' to exit): ")
+        if question.strip().lower() == "q" or question.strip().lower() == "quit":
+            break
+        response = answer_engine.ask_stream(question)
+
+        answer = "Answer: "
+        citations = ""
+        for partial_response in response:
+            if partial_response.answer and not partial_response.is_final:
+                answer += partial_response.answer
+                sys.stdout.write(partial_response.answer)
+                sys.stdout.flush()
+            if partial_response.citations:
+                citations = partial_response.citations
+            if partial_response.is_final:
+                print()
+                break
+
+        rprint(f"[blue]Citations:[/blue] {citations}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples copy/streaming_deep_research.py
+++ b/examples copy/streaming_deep_research.py
@@ -1,0 +1,46 @@
+import sys
+from auxknow import AuxKnow
+from rich import print as rprint
+
+
+def main():
+    """
+    Basic use-case of AuxKnow, where you perform deep research and see the response as it is being generated.
+    AuxKnow responds with a detailed answer and citations using 'deep research' mode with streaming.
+    """
+    answer_engine = AuxKnow(verbose=True)
+    question = ""
+
+    config = {
+        "auto_query_restructuring": True,
+        "auto_model_routing": False,
+        "answer_length_in_paragraphs": 3,
+        "lines_per_paragraph": 5,
+        "auto_prompt_augment": True,
+    }
+    answer_engine.set_config(config)
+
+    while question.strip().lower() != "q" or question.strip().lower() != "quit":
+        question = input("💡 Enter a question for AuxKnow  (Press 'q' to exit): ")
+        if question.strip().lower() == "q" or question.strip().lower() == "quit":
+            break
+        response = answer_engine.ask_stream(question, deep_research=True)
+
+        answer = "Answer: "
+        citations = ""
+        for partial_response in response:
+            if partial_response.answer and not partial_response.is_final:
+                answer += partial_response.answer
+                sys.stdout.write(partial_response.answer)
+                sys.stdout.flush()
+            if partial_response.citations:
+                citations = partial_response.citations
+            if partial_response.is_final:
+                print()
+                break
+
+        rprint(f"[blue]Citations:[/blue] {citations}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples copy/streaming_fast_mode.py
+++ b/examples copy/streaming_fast_mode.py
@@ -1,0 +1,37 @@
+import sys
+from auxknow import AuxKnow
+from rich import print as rprint
+
+
+def main():
+    """ "
+    Basic use-case of AuxKnow, where the response is generated in fast mode (< 5 seconds).
+    The user sees the response as it is being generated with streaming.
+    """
+    answer_engine = AuxKnow(verbose=True)
+    question = ""
+
+    while question.strip().lower() != "q" or question.strip().lower() != "quit":
+        question = input("💡 Enter a question for AuxKnow  (Press 'q' to exit): ")
+        if question.strip().lower() == "q" or question.strip().lower() == "quit":
+            break
+        response = answer_engine.ask_stream(question, fast_mode=True)
+
+        answer = "Answer: "
+        citations = ""
+        for partial_response in response:
+            if partial_response.answer and not partial_response.is_final:
+                answer += partial_response.answer
+                sys.stdout.write(partial_response.answer)
+                sys.stdout.flush()
+            if partial_response.citations:
+                citations = partial_response.citations
+            if partial_response.is_final:
+                print()
+                break
+
+        rprint(f"[blue]Citations:[/blue] {citations}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/quickstart_sonar_reasoning.py
+++ b/examples/quickstart_sonar_reasoning.py
@@ -1,0 +1,30 @@
+from auxknow import AuxKnow
+from rich import print as rprint
+import os
+
+def main():
+    """
+    This is a basic use-case of AuxKnow, where your responses are generated using sonar reasoning mode.
+    AuxKnow responds with a detailed answer and citations using 'sonar-reasoning' mode.
+    """
+    try:
+        answer_engine = AuxKnow(
+            verbose=True,
+        )
+        question = "Why is the sky blue? Provide a quantum spiritual explanation."
+
+        response = answer_engine.ask(
+            question,
+            enable_reasoning=True,
+        )
+
+        answer = response.answer
+        citations = response.citations
+        rprint(f"[green]Answer:[/green] {answer}")
+        rprint(f"[blue]Citations:[/blue] {citations}")
+
+    except Exception as e:
+        rprint(f"[red]❌ An error occurred: {e}[/red]")
+
+if __name__ == "__main__":
+    main()

--- a/examples/session_sonar_reasoning.py
+++ b/examples/session_sonar_reasoning.py
@@ -1,0 +1,39 @@
+import sys
+from auxknow import AuxKnow
+from rich import print as rprint
+
+
+def main():
+    """
+    Basic use-case of AuxKnow, where you use sonar reasoning mode and get the response as it is being generated.
+    AuxKnow responds with a detailed answer and citations using 'sonar-reasoning' mode with streaming.
+    """
+    try:
+        answer_engine = AuxKnow(verbose=True)
+        question = ""
+
+        while question.strip().lower() != "q" or question.strip().lower() != "quit":
+            question = input("💡 Enter a question for AuxKnow  (Press 'q' to exit): ")
+            if question.strip().lower() == "q" or question.strip().lower() == "quit":
+                break
+            response = answer_engine.ask_stream(question, enable_reasoning=True)
+
+            answer = "Answer: "
+            citations = ""
+            for partial_response in response:
+                if partial_response.answer and not partial_response.is_final:
+                    answer += partial_response.answer
+                    sys.stdout.write(partial_response.answer)
+                    sys.stdout.flush()
+                if partial_response.citations:
+                    citations = partial_response.citations
+                if partial_response.is_final:
+                    print()
+                    break
+
+            rprint(f"[blue]Citations:[/blue] {citations}")
+    except Exception as e:
+        rprint(f"[red]❌ An error occurred: {e}[/red]")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Updated `usage.md` and API reference to include examples and usage of the `enable_reasoning` argument. Also added the `enable_reasoning` param to relevant function calls to reflect actual usage.

Changes include:
- New examples in `usage.md` and API reference for `enable_reasoning`
- Applied `enable_reasoning=True` in relevant function calls
- Added a brief explanation of reasoning mode and its benefits